### PR TITLE
複数の目標を管理できるようにする

### DIFF
--- a/src/ManageApp.tsx
+++ b/src/ManageApp.tsx
@@ -8,12 +8,12 @@ import {
 } from "./firebase";
 import {
   ensurePageOwner,
-  saveGoal,
+  saveGoals,
   saveMeasurementMeta,
   saveMeasurements,
   subscribePage,
 } from "./lib/store";
-import { computeGoalProgress } from "./lib/stats";
+import { computeGoalProgresses } from "./lib/stats";
 import { GoalCard } from "./components/GoalCard";
 import { GoalEditor } from "./components/GoalEditor";
 import { LabelEditor } from "./components/LabelEditor";
@@ -53,6 +53,10 @@ export default function ManageApp() {
   const isOwner = Boolean(
     FIREBASE_ENABLED && user && (!page.ownerUid || page.ownerUid === user.uid),
   );
+  const goals = useMemo(
+    () => page.goals ?? (page.goal ? [page.goal] : []),
+    [page.goals, page.goal],
+  );
 
   async function handleImport(measurements: Measurement[]) {
     if (FIREBASE_ENABLED && user && isOwner) {
@@ -67,11 +71,16 @@ export default function ManageApp() {
   }
 
   async function handleGoalSave(goal: Goal) {
+    const nextGoals = [...goals, { ...goal, id: createGoalId() }];
     if (FIREBASE_ENABLED && user && isOwner) {
       await ensurePageOwner(pageId, user.uid);
-      await saveGoal(pageId, goal);
+      await saveGoals(pageId, nextGoals);
     } else {
-      setPage((prev) => ({ ...prev, goal }));
+      setPage((prev) => ({
+        ...prev,
+        goals: nextGoals,
+        goal: nextGoals[nextGoals.length - 1],
+      }));
     }
   }
 
@@ -95,9 +104,14 @@ export default function ManageApp() {
     }
   }
 
-  const progress = useMemo(
-    () => computeGoalProgress(page.measurements, page.goal),
-    [page.measurements, page.goal],
+  const progresses = useMemo(
+    () => computeGoalProgresses(page.measurements, goals),
+    [page.measurements, goals],
+  );
+  const latestMeasurement = page.measurements[page.measurements.length - 1];
+  const nextGoalDraft = useMemo(
+    () => buildNextGoalDraft(goals),
+    [goals],
   );
 
   return (
@@ -147,22 +161,25 @@ export default function ManageApp() {
         </div>
       )}
 
-      <GoalCard progress={progress} />
+      <GoalCard progresses={progresses} />
 
       <div className="card">
         <h2>体重の推移</h2>
         <WeightChart
           measurements={page.measurements}
-          goal={page.goal}
-          startWeight={progress.startWeight}
+          goals={goals}
+          progresses={progresses}
           onPointClick={isOwner ? setEditingDate : undefined}
         />
       </div>
 
       <GoalEditor
-        value={page.goal}
+        key={`${nextGoalDraft.startDate}-${nextGoalDraft.endDate}-${nextGoalDraft.targetKg}`}
+        value={nextGoalDraft}
         onSave={handleGoalSave}
         disabled={FIREBASE_ENABLED ? !isOwner : false}
+        title="次の目標を追加"
+        submitLabel="追加"
       />
 
       <Uploader
@@ -173,7 +190,7 @@ export default function ManageApp() {
       <footer>
         <div>
           {page.measurements.length} 件の測定値
-          {progress.latestDate && ` · 最終更新 ${progress.latestDate}`}
+          {latestMeasurement?.date && ` · 最終更新 ${latestMeasurement.date}`}
         </div>
       </footer>
 
@@ -192,6 +209,43 @@ export default function ManageApp() {
       })()}
     </div>
   );
+}
+
+function buildNextGoalDraft(goals: Goal[]): Goal {
+  const latest = goals[goals.length - 1];
+  const todayDate = today();
+  const nextStartDate = latest ? addDays(latest.endDate, 1) : todayDate;
+  const startDate = nextStartDate < todayDate ? todayDate : nextStartDate;
+  return {
+    startDate,
+    endDate: addDays(startDate, 30),
+    targetKg: latest?.targetKg ?? 2,
+  };
+}
+
+function createGoalId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `goal-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function today(): string {
+  const d = new Date();
+  return isoDate(d);
+}
+
+function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  return isoDate(d);
+}
+
+function isoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
 }
 
 function mergeMeasurements(

--- a/src/ViewerApp.tsx
+++ b/src/ViewerApp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { DEFAULT_PAGE_ID, FIREBASE_ENABLED } from "./firebase";
 import { subscribePage } from "./lib/store";
-import { computeGoalProgress } from "./lib/stats";
+import { computeGoalProgresses } from "./lib/stats";
 import { GoalCard } from "./components/GoalCard";
 import { WeightChart } from "./components/WeightChart";
 import type { PageData } from "./types";
@@ -22,10 +22,15 @@ export default function ViewerApp() {
     return subscribePage(pageId, setPage);
   }, [pageId]);
 
-  const progress = useMemo(
-    () => computeGoalProgress(page.measurements, page.goal),
-    [page.measurements, page.goal],
+  const goals = useMemo(
+    () => page.goals ?? (page.goal ? [page.goal] : []),
+    [page.goals, page.goal],
   );
+  const progresses = useMemo(
+    () => computeGoalProgresses(page.measurements, goals),
+    [page.measurements, goals],
+  );
+  const latestMeasurement = page.measurements[page.measurements.length - 1];
 
   return (
     <div className="app">
@@ -35,21 +40,21 @@ export default function ViewerApp() {
         </div>
       </header>
 
-      <GoalCard progress={progress} />
+      <GoalCard progresses={progresses} />
 
       <div className="card">
         <h2>体重の推移</h2>
         <WeightChart
           measurements={page.measurements}
-          goal={page.goal}
-          startWeight={progress.startWeight}
+          goals={goals}
+          progresses={progresses}
         />
       </div>
 
       <footer>
         <div>
           {page.measurements.length} 件の測定値
-          {progress.latestDate && ` · 最終更新 ${progress.latestDate}`}
+          {latestMeasurement?.date && ` · 最終更新 ${latestMeasurement.date}`}
         </div>
       </footer>
     </div>

--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -1,11 +1,12 @@
 import type { GoalProgress } from "../lib/stats";
 
 type Props = {
-  progress: GoalProgress;
+  progresses: GoalProgress[];
 };
 
-export function GoalCard({ progress }: Props) {
-  if (!progress.hasGoal) {
+export function GoalCard({ progresses }: Props) {
+  const visible = progresses.filter((progress) => progress.hasGoal);
+  if (visible.length === 0) {
     return (
       <div className="card">
         <h2>目標</h2>
@@ -15,12 +16,31 @@ export function GoalCard({ progress }: Props) {
       </div>
     );
   }
+
+  return (
+    <div className="goal-cards">
+      {visible.map((progress) => (
+        <GoalProgressCard
+          key={progress.goalId ?? `${progress.startDate}-${progress.endDate}`}
+          progress={progress}
+        />
+      ))}
+    </div>
+  );
+}
+
+function GoalProgressCard({ progress }: { progress: GoalProgress }) {
   const {
     startDate,
     endDate,
     targetKg,
+    targetWeight,
     startWeight,
     latestWeight,
+    bestWeight,
+    achieved,
+    achievedDate,
+    achievedWeight,
     delta,
     remaining,
     totalDays,
@@ -30,34 +50,41 @@ export function GoalCard({ progress }: Props) {
   } = progress;
 
   return (
-    <div className="card">
-      <h2>
-        {startDate} 〜 {endDate} の進捗（目標 -{targetKg} kg）
-      </h2>
+    <div className={`card goal-card${achieved ? " achieved" : ""}`}>
+      <div className="goal-card-heading">
+        <h2>
+          {startDate} 〜 {endDate} の進捗（目標 -{targetKg} kg）
+        </h2>
+        {achieved && <span className="goal-badge">達成</span>}
+      </div>
       <div className="goal-grid">
         <Stat label="開始時体重" value={fmtKg(startWeight)} />
-        <Stat label="現在体重" value={fmtKg(latestWeight)} />
+        <Stat label="目標体重" value={fmtKg(targetWeight)} />
+        <Stat label="期間内最終" value={fmtKg(latestWeight)} />
+        <Stat label="期間内最小" value={fmtKg(bestWeight)} tone={achieved ? "ok" : undefined} />
         <Stat
           label="開始比"
           value={delta != null ? `${signed(delta)} kg` : "—"}
           tone={delta == null ? undefined : delta < 0 ? "ok" : "danger"}
         />
         <Stat
-          label={`目標まで`}
+          label="目標まで"
           value={
-            remaining == null
-              ? "—"
-              : remaining <= 0
-                ? "達成!"
+            achieved
+              ? achievedWeight != null
+                ? `${achievedDate} に ${achievedWeight.toFixed(1)} kg`
+                : "達成!"
+              : remaining == null
+                ? "—"
                 : `あと ${remaining.toFixed(1)} kg`
           }
-          tone={remaining == null ? undefined : remaining <= 0 ? "ok" : undefined}
+          tone={achieved ? "ok" : undefined}
         />
         <Stat
           label="経過"
           value={`${elapsedDays} / ${totalDays} 日 (${Math.round(periodProgress * 100)}%)`}
         />
-        {onTrack === true && (
+        {onTrack === true && !achieved && (
           <Stat label="ペース" value="On track" tone="ok" />
         )}
       </div>

--- a/src/components/GoalEditor.tsx
+++ b/src/components/GoalEditor.tsx
@@ -5,6 +5,8 @@ type Props = {
   value?: Goal;
   onSave: (v: Goal) => void | Promise<void>;
   disabled?: boolean;
+  title?: string;
+  submitLabel?: string;
 };
 
 function today(): string {
@@ -24,7 +26,13 @@ function addDays(iso: string, days: number): string {
   return `${y}-${m}-${da}`;
 }
 
-export function GoalEditor({ value, onSave, disabled }: Props) {
+export function GoalEditor({
+  value,
+  onSave,
+  disabled,
+  title = "目標期間",
+  submitLabel = "保存",
+}: Props) {
   const [startDate, setStartDate] = useState(value?.startDate ?? today());
   const [endDate, setEndDate] = useState(
     value?.endDate ?? addDays(today(), 30),
@@ -43,7 +51,7 @@ export function GoalEditor({ value, onSave, disabled }: Props) {
 
   return (
     <div className="card">
-      <h2>目標期間</h2>
+      <h2>{title}</h2>
       <div className="goal-editor" style={{ flexWrap: "wrap" }}>
         <label>
           <span>開始</span>
@@ -102,7 +110,7 @@ export function GoalEditor({ value, onSave, disabled }: Props) {
             }
           }}
         >
-          {saving ? "保存中..." : "保存"}
+          {saving ? "保存中..." : submitLabel}
         </button>
         {disabled && (
           <span className="hint" style={{ color: "var(--muted)", fontSize: 11, letterSpacing: "0.1em" }}>

--- a/src/components/WeightChart.tsx
+++ b/src/components/WeightChart.tsx
@@ -2,6 +2,7 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceArea,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -9,21 +10,22 @@ import {
   type TooltipProps,
 } from "recharts";
 import { getLabelDef } from "../lib/labels";
+import type { GoalProgress } from "../lib/stats";
 import type { Goal, Measurement, Running } from "../types";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type Props = {
   measurements: Measurement[];
-  goal?: Goal;
-  startWeight?: number | null;
+  goals?: Goal[];
+  progresses?: GoalProgress[];
   onPointClick?: (date: string) => void;
 };
 
 type Row = {
   date: string;
   weightKg?: number;
-  idealWeight?: number;
+  goalPaces?: { label: string; value: number }[];
   labels?: string[];
   note?: string;
   running?: Running;
@@ -33,6 +35,8 @@ type Row = {
   bmrKcal?: number;
   visceralFatLevel?: number;
   boneKg?: number;
+} & {
+  [key: `idealWeight${number}`]: number | undefined;
 };
 
 function pad(n: number): string {
@@ -51,71 +55,80 @@ function parseISO(iso: string): Date | null {
 
 function buildRows(
   measurements: Measurement[],
-  goal: Goal | undefined,
-  startWeight: number | null | undefined,
+  goals: Goal[],
+  progresses: GoalProgress[],
 ): Row[] {
   const byDate = new Map(measurements.map((m) => [m.date, m]));
+  const dates = [
+    ...measurements.map((m) => m.date),
+    ...goals.flatMap((goal) => [goal.startDate, goal.endDate]),
+  ];
 
-  if (goal) {
-    const start = parseISO(goal.startDate);
-    const end = parseISO(goal.endDate);
-    if (start && end && end >= start) {
-      const totalDays = Math.max(
+  if (dates.length === 0) return [];
+  const minDate = dates.reduce((a, b) => (a < b ? a : b));
+  const maxDate = dates.reduce((a, b) => (a > b ? a : b));
+  const start = parseISO(minDate);
+  const end = parseISO(maxDate);
+  if (!start || !end || end < start) return [];
+
+  const totalDays = Math.max(
+    0,
+    Math.round((end.getTime() - start.getTime()) / DAY_MS),
+  );
+  const rows: Row[] = [];
+  for (let i = 0; i <= totalDays; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    const dateStr = isoDate(d);
+    const m = byDate.get(dateStr);
+    const row: Row = {
+      date: dateStr,
+      weightKg: m?.weightKg,
+      labels: m?.labels,
+      note: m?.note,
+      running: m?.running,
+      bodyFatPct: m?.bodyFatPct,
+      bmi: m?.bmi,
+      muscleKg: m?.muscleKg,
+      bmrKcal: m?.bmrKcal,
+      visceralFatLevel: m?.visceralFatLevel,
+      boneKg: m?.boneKg,
+    };
+    goals.forEach((goal, index) => {
+      const progress = progresses[index];
+      const goalStart = parseISO(goal.startDate);
+      const goalEnd = parseISO(goal.endDate);
+      if (!goalStart || !goalEnd || goalEnd < goalStart) return;
+      if (dateStr < goal.startDate || dateStr > goal.endDate) return;
+      if (progress?.startWeight == null) return;
+      const goalTotalDays = Math.max(
         1,
-        Math.round((end.getTime() - start.getTime()) / DAY_MS),
+        Math.round((goalEnd.getTime() - goalStart.getTime()) / DAY_MS),
       );
-      const rows: Row[] = [];
-      for (let i = 0; i <= totalDays; i++) {
-        const d = new Date(start);
-        d.setDate(start.getDate() + i);
-        const dateStr = isoDate(d);
-        const m = byDate.get(dateStr);
-        const ideal =
-          startWeight != null
-            ? startWeight - goal.targetKg * (i / totalDays)
-            : undefined;
-        rows.push({
-          date: dateStr,
-          weightKg: m?.weightKg,
-          idealWeight: ideal,
-          labels: m?.labels,
-          note: m?.note,
-          running: m?.running,
-          bodyFatPct: m?.bodyFatPct,
-          bmi: m?.bmi,
-          muscleKg: m?.muscleKg,
-          bmrKcal: m?.bmrKcal,
-          visceralFatLevel: m?.visceralFatLevel,
-          boneKg: m?.boneKg,
-        });
-      }
-      return rows;
-    }
+      const goalElapsedDays = Math.round(
+        (d.getTime() - goalStart.getTime()) / DAY_MS,
+      );
+      const value =
+        progress.startWeight - goal.targetKg * (goalElapsedDays / goalTotalDays);
+      const key = idealKey(index);
+      row[key] = value;
+      row.goalPaces = [
+        ...(row.goalPaces ?? []),
+        { label: `${index + 1}つ目の目標ペース`, value },
+      ];
+    });
+    rows.push(row);
   }
-
-  // 目標が無い、または期間が壊れている場合は測定日だけプロット
-  return measurements.map((m) => ({
-    date: m.date,
-    weightKg: m.weightKg,
-    labels: m.labels,
-    note: m.note,
-    running: m.running,
-    bodyFatPct: m.bodyFatPct,
-    bmi: m.bmi,
-    muscleKg: m.muscleKg,
-    bmrKcal: m.bmrKcal,
-    visceralFatLevel: m.visceralFatLevel,
-    boneKg: m.boneKg,
-  }));
+  return rows;
 }
 
 export function WeightChart({
   measurements,
-  goal,
-  startWeight,
+  goals = [],
+  progresses = [],
   onPointClick,
 }: Props) {
-  const data = buildRows(measurements, goal, startWeight ?? null);
+  const data = buildRows(measurements, goals, progresses);
 
   if (data.length === 0 || measurements.length === 0) {
     return (
@@ -126,7 +139,10 @@ export function WeightChart({
   const numeric: number[] = data.flatMap((r) => {
     const list: number[] = [];
     if (typeof r.weightKg === "number") list.push(r.weightKg);
-    if (typeof r.idealWeight === "number") list.push(r.idealWeight);
+    goals.forEach((_, index) => {
+      const value = r[idealKey(index)];
+      if (typeof value === "number") list.push(value);
+    });
     return list;
   });
   const min = Math.floor(Math.min(...numeric) - 0.5);
@@ -165,18 +181,32 @@ export function WeightChart({
             content={<DetailTooltip />}
             cursor={{ stroke: "rgba(10,10,10,0.2)", strokeDasharray: "2 4" }}
           />
-          {/* 理想ペース線 */}
-          <Line
-            type="linear"
-            dataKey="idealWeight"
-            stroke="rgba(10,10,10,0.35)"
-            strokeWidth={1}
-            strokeDasharray="3 4"
-            dot={false}
-            activeDot={false}
-            connectNulls
-            isAnimationActive={false}
-          />
+          {progresses.map((progress) =>
+            progress.achieved && progress.startDate && progress.endDate ? (
+              <ReferenceArea
+                key={`achieved-${progress.goalId ?? progress.startDate}`}
+                x1={progress.startDate}
+                x2={progress.endDate}
+                fill="#dff3e4"
+                fillOpacity={0.7}
+                strokeOpacity={0}
+              />
+            ) : null,
+          )}
+          {goals.map((goal, index) => (
+            <Line
+              key={goal.id ?? `${goal.startDate}-${goal.endDate}`}
+              type="linear"
+              dataKey={idealKey(index)}
+              stroke={progresses[index]?.achieved ? "#177245" : "rgba(10,10,10,0.35)"}
+              strokeWidth={1}
+              strokeDasharray="3 4"
+              dot={false}
+              activeDot={false}
+              connectNulls
+              isAnimationActive={false}
+            />
+          ))}
           {/* 実体重 */}
           <Line
             type="monotone"
@@ -203,6 +233,10 @@ type DotProps = {
   key?: string | number;
   index?: number;
 };
+
+function idealKey(index: number): `idealWeight${number}` {
+  return `idealWeight${index}`;
+}
 
 function CustomDot({
   cx,
@@ -253,16 +287,17 @@ function CustomDot({
 function DetailTooltip({ active, payload }: TooltipProps<number, string>) {
   if (!active || !payload || payload.length === 0) return null;
   const row = payload[0]!.payload as Row;
-  if (row.weightKg == null && row.idealWeight == null) return null;
   const rows: { label: string; value: string | undefined; unit?: string }[] = [];
   if (row.weightKg != null)
     rows.push({ label: "体重", value: fmt(row.weightKg, 1), unit: "kg" });
-  if (row.idealWeight != null)
+  row.goalPaces?.forEach((pace) =>
     rows.push({
-      label: "ペース",
-      value: fmt(row.idealWeight, 1),
+      label: pace.label,
+      value: fmt(pace.value, 1),
       unit: "kg",
-    });
+    }),
+  );
+  if (rows.length === 0) return null;
   if (row.bodyFatPct != null)
     rows.push({ label: "体脂肪率", value: fmt(row.bodyFatPct, 1), unit: "%" });
   if (row.bmi != null) rows.push({ label: "BMI", value: fmt(row.bmi, 1) });

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -2,12 +2,18 @@ import type { Goal, Measurement } from "../types";
 
 export type GoalProgress = {
   hasGoal: boolean;
+  goalId: string | null;
   startDate: string | null;
   endDate: string | null;
   targetKg: number;
+  targetWeight: number | null;
   startWeight: number | null;
   latestWeight: number | null;
   latestDate: string | null;
+  bestWeight: number | null;
+  achieved: boolean;
+  achievedDate: string | null;
+  achievedWeight: number | null;
   /** 現在体重 - 開始体重 (負なら減量できている) */
   delta: number | null;
   /** 目標まで残り kg (正なら残り、負なら超過達成) */
@@ -22,6 +28,16 @@ export type GoalProgress = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function computeGoalProgresses(
+  measurements: Measurement[],
+  goals: Goal[] | undefined,
+  now: Date = new Date(),
+): GoalProgress[] {
+  return (goals ?? []).map((goal) =>
+    computeGoalProgress(measurements, goal, now),
+  );
+}
 
 export function computeGoalProgress(
   measurements: Measurement[],
@@ -43,19 +59,37 @@ export function computeGoalProgress(
   const daysLeft = Math.max(0, totalDays - elapsedDays);
   const periodProgress = elapsedDays / totalDays;
 
-  const startWeight = pickStartWeight(measurements, goal.startDate);
-  const latest = measurements.length > 0 ? measurements[measurements.length - 1]! : null;
+  const periodMeasurements = measurements.filter(
+    (m) => m.date >= goal.startDate && m.date <= goal.endDate,
+  );
+  const startWeight = pickStartWeight(measurements, goal, now);
+  const latest =
+    periodMeasurements.length > 0
+      ? periodMeasurements[periodMeasurements.length - 1]!
+      : goal.startDate > isoDate(now) && measurements.length > 0
+        ? measurements[measurements.length - 1]!
+        : null;
   const latestWeight = latest?.weightKg ?? null;
   const latestDate = latest?.date ?? null;
+  const targetWeight =
+    startWeight != null ? round1(startWeight - goal.targetKg) : null;
+  const best = pickBestWeight(periodMeasurements);
+  const bestWeight = best?.weightKg ?? null;
+  const achievedMeasurement =
+    targetWeight == null
+      ? null
+      : periodMeasurements.find((m) => m.weightKg <= targetWeight) ?? null;
 
   const delta =
     startWeight != null && latestWeight != null
       ? round1(latestWeight - startWeight)
       : null;
 
-  // 目標は「減量量(正)」として持つ。delta が負(減った) で targetKg が正なら
-  // 残り = targetKg + delta
-  const remaining = delta != null ? round1(goal.targetKg + delta) : null;
+  const weightForRemaining = bestWeight ?? latestWeight;
+  const remaining =
+    targetWeight != null && weightForRemaining != null
+      ? round1(weightForRemaining - targetWeight)
+      : null;
 
   const expectedDelta = -goal.targetKg * periodProgress;
   const onTrack =
@@ -63,12 +97,18 @@ export function computeGoalProgress(
 
   return {
     hasGoal: true,
+    goalId: goal.id ?? null,
     startDate: goal.startDate,
     endDate: goal.endDate,
     targetKg: goal.targetKg,
+    targetWeight,
     startWeight,
     latestWeight,
     latestDate,
+    bestWeight,
+    achieved: Boolean(achievedMeasurement),
+    achievedDate: achievedMeasurement?.date ?? null,
+    achievedWeight: achievedMeasurement?.weightKg ?? null,
     delta,
     remaining,
     totalDays,
@@ -81,20 +121,41 @@ export function computeGoalProgress(
 
 function pickStartWeight(
   measurements: Measurement[],
-  startDate: string,
+  goal: Goal,
+  now: Date,
 ): number | null {
   if (measurements.length === 0) return null;
-  // 開始日以降で最初の測定値を採用
-  const onOrAfter = measurements.find((m) => m.date >= startDate);
+  // 期間内で最初の測定値を採用
+  const onOrAfter = measurements.find(
+    (m) => m.date >= goal.startDate && m.date <= goal.endDate,
+  );
   if (onOrAfter) return onOrAfter.weightKg;
   // 期間が未来 → 直近の値で代用
-  return measurements[measurements.length - 1]!.weightKg;
+  if (goal.startDate > isoDate(now)) {
+    return measurements[measurements.length - 1]!.weightKg;
+  }
+  return null;
+}
+
+function pickBestWeight(measurements: Measurement[]): Measurement | null {
+  if (measurements.length === 0) return null;
+  return measurements.reduce((best, current) =>
+    current.weightKg < best.weightKg ? current : best,
+  );
 }
 
 function parseISODate(iso: string): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return null;
   const d = new Date(`${iso}T00:00:00`);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function isoDate(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 function round1(n: number): number {
@@ -104,12 +165,18 @@ function round1(n: number): number {
 function emptyProgress(): GoalProgress {
   return {
     hasGoal: false,
+    goalId: null,
     startDate: null,
     endDate: null,
     targetKg: 0,
+    targetWeight: null,
     startWeight: null,
     latestWeight: null,
     latestDate: null,
+    bestWeight: null,
+    achieved: false,
+    achievedDate: null,
+    achievedWeight: null,
     delta: null,
     remaining: null,
     totalDays: 0,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -16,18 +16,67 @@ export function pageDocPath(pageId: string) {
   return ["pages", pageId] as const;
 }
 
-function readGoal(data: Record<string, unknown> | undefined): Goal | undefined {
-  if (!data) return undefined;
-  const g = data.goal as Partial<Goal> | undefined;
+function normalizeGoal(g: Partial<Goal> | undefined): Goal | undefined {
   if (
     g &&
     typeof g.startDate === "string" &&
     typeof g.endDate === "string" &&
     typeof g.targetKg === "number"
   ) {
-    return { startDate: g.startDate, endDate: g.endDate, targetKg: g.targetKg };
+    const goal = {
+      id: typeof g.id === "string" && g.id !== "" ? g.id : undefined,
+      startDate: g.startDate,
+      endDate: g.endDate,
+      targetKg: g.targetKg,
+    };
+    return { ...goal, id: goal.id ?? stableGoalId(goal) };
   }
   return undefined;
+}
+
+function stableGoalId(goal: Pick<Goal, "startDate" | "endDate" | "targetKg">) {
+  return `goal-${goalSignature(goal)}`
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .replace(/-+/g, "-");
+}
+
+function goalSignature(goal: Pick<Goal, "startDate" | "endDate" | "targetKg">) {
+  return `${goal.startDate}-${goal.endDate}-${goal.targetKg}`;
+}
+
+function sortGoals(goals: Goal[]): Goal[] {
+  return [...goals].sort((a, b) => {
+    if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1;
+    if (a.endDate !== b.endDate) return a.endDate < b.endDate ? -1 : 1;
+    return a.targetKg - b.targetKg;
+  });
+}
+
+function dedupeGoals(goals: Goal[]): Goal[] {
+  const byId = new Map<string, Goal>();
+  const seenSignatures = new Set<string>();
+  for (const goal of goals) {
+    const signature = goalSignature(goal);
+    if (seenSignatures.has(signature)) continue;
+    seenSignatures.add(signature);
+    byId.set(goal.id ?? stableGoalId(goal), goal);
+  }
+  return sortGoals(Array.from(byId.values()));
+}
+
+function readGoals(data: Record<string, unknown> | undefined): Goal[] {
+  if (!data) return [];
+  const goals = Array.isArray(data.goals)
+    ? data.goals
+        .map((g) => normalizeGoal(g as Partial<Goal> | undefined))
+        .filter((g): g is Goal => Boolean(g))
+    : [];
+  const legacyGoal = normalizeGoal(data.goal as Partial<Goal> | undefined);
+  return dedupeGoals(legacyGoal ? [...goals, legacyGoal] : goals);
+}
+
+function latestGoal(goals: Goal[]): Goal | undefined {
+  return goals.length > 0 ? goals[goals.length - 1] : undefined;
 }
 
 export async function fetchPage(pageId: string): Promise<PageData | null> {
@@ -37,11 +86,11 @@ export async function fetchPage(pageId: string): Promise<PageData | null> {
   const snap = await getDoc(pageRef);
 
   let ownerUid: string | undefined;
-  let goal: Goal | undefined;
+  let goals: Goal[] = [];
   if (snap.exists()) {
     const data = snap.data() as Record<string, unknown>;
     ownerUid = data.ownerUid as string | undefined;
-    goal = readGoal(data);
+    goals = readGoals(data);
   }
 
   const measurementsSnap = await getDocs(
@@ -51,7 +100,7 @@ export async function fetchPage(pageId: string): Promise<PageData | null> {
     .map((d) => d.data() as Measurement)
     .sort((a, b) => (a.date < b.date ? -1 : 1));
 
-  return { pageId, ownerUid, goal, measurements };
+  return { pageId, ownerUid, goals, goal: latestGoal(goals), measurements };
 }
 
 export function subscribePage(
@@ -84,10 +133,16 @@ export function subscribePage(
       pageData = {
         ...pageData,
         ownerUid: data.ownerUid as string | undefined,
-        goal: readGoal(data),
+        goals: readGoals(data),
       };
+      pageData = { ...pageData, goal: latestGoal(pageData.goals ?? []) };
     } else {
-      pageData = { ...pageData, ownerUid: undefined, goal: undefined };
+      pageData = {
+        ...pageData,
+        ownerUid: undefined,
+        goals: [],
+        goal: undefined,
+      };
     }
     pageLoaded = true;
     emit();
@@ -124,12 +179,20 @@ export async function ensurePageOwner(
   }
 }
 
-export async function saveGoal(pageId: string, goal: Goal): Promise<void> {
+export async function saveGoals(pageId: string, goals: Goal[]): Promise<void> {
   const fb = getFirebase();
   if (!fb) throw new Error("Firebase is not configured");
+  const normalized = dedupeGoals(
+    goals.map((goal) => ({ ...goal, id: goal.id ?? stableGoalId(goal) })),
+  );
+  const latest = latestGoal(normalized);
   await setDoc(
     doc(fb.db, ...pageDocPath(pageId)),
-    { goal, updatedAt: serverTimestamp() },
+    {
+      goals: normalized,
+      goal: latest ?? deleteField(),
+      updatedAt: serverTimestamp(),
+    },
     { merge: true },
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,6 +9,9 @@
   --hairline: rgba(10, 10, 10, 0.22);
   --ok: #0a0a0a;
   --danger: #7c1d1d;
+  --success-bg: #e7f5e9;
+  --success-border: #9fd2ad;
+  --success-fg: #14532d;
   font-family: "Inter", "Noto Sans JP", -apple-system, BlinkMacSystemFont,
     "Helvetica Neue", system-ui, sans-serif;
   font-feature-settings: "ss01", "cv11";
@@ -151,6 +154,40 @@ input[type="file"] {
   margin: 0 0 16px;
 }
 
+.goal-cards {
+  display: grid;
+  gap: 12px;
+}
+.goal-card {
+  padding-left: 0;
+  padding-right: 0;
+}
+.goal-card.achieved {
+  background: var(--success-bg);
+  border: 1px solid var(--success-border);
+  border-radius: 6px;
+  padding: 18px;
+}
+.goal-card-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+.goal-card-heading h2 {
+  margin-bottom: 0;
+}
+.goal-badge {
+  flex: 0 0 auto;
+  color: var(--success-fg);
+  border: 1px solid var(--success-border);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+}
 .goal-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -174,7 +211,7 @@ input[type="file"] {
   font-variant-numeric: tabular-nums;
 }
 .goal-grid .stat .value.ok {
-  color: var(--ok);
+  color: var(--success-fg);
 }
 .goal-grid .stat .value.danger {
   color: var(--danger);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type Running = {
 };
 
 export type Goal = {
+  id?: string;
   /** YYYY-MM-DD */
   startDate: string;
   /** YYYY-MM-DD */
@@ -33,6 +34,7 @@ export type Goal = {
 export type PageData = {
   pageId: string;
   ownerUid?: string;
+  goals?: Goal[];
   goal?: Goal;
   measurements: Measurement[];
 };


### PR DESCRIPTION
## 概要
- 複数の目標を保存・表示できるようにしました。
- 既存の単一目標データも読み込めるように後方互換を保っています。
- 期間内に一度でも目標体重へ到達した場合、その目標を達成扱いにして緑背景で表示します。
- グラフ上でも達成済み期間を薄い緑で表示します。

## 背景
6月末までの目標を達成後も表示に残しつつ、7月末までの次の目標を追加して並べて見られるようにするためです。

## 確認したこと
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build
- git diff --check