### PR TITLE
目標カードの表示順と達成表示を調整する

### DIFF
--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -5,7 +5,9 @@ type Props = {
 };
 
 export function GoalCard({ progresses }: Props) {
-  const visible = progresses.filter((progress) => progress.hasGoal);
+  const visible = progresses
+    .filter((progress) => progress.hasGoal)
+    .sort(compareNewestFirst);
   if (visible.length === 0) {
     return (
       <div className="card">
@@ -16,17 +18,37 @@ export function GoalCard({ progresses }: Props) {
       </div>
     );
   }
+  const latest = visible[0]!;
+  const past = visible.slice(1);
 
   return (
     <div className="goal-cards">
-      {visible.map((progress) => (
-        <GoalProgressCard
-          key={progress.goalId ?? `${progress.startDate}-${progress.endDate}`}
-          progress={progress}
-        />
-      ))}
+      <GoalProgressCard progress={latest} />
+      {past.length > 0 && (
+        <details className="past-goals">
+          <summary>過去の目標 {past.length}件</summary>
+          <div className="goal-cards">
+            {past.map((progress) => (
+              <GoalProgressCard
+                key={progress.goalId ?? `${progress.startDate}-${progress.endDate}`}
+                progress={progress}
+              />
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
+}
+
+function compareNewestFirst(a: GoalProgress, b: GoalProgress): number {
+  const aEnd = a.endDate ?? "";
+  const bEnd = b.endDate ?? "";
+  if (aEnd !== bEnd) return aEnd > bEnd ? -1 : 1;
+  const aStart = a.startDate ?? "";
+  const bStart = b.startDate ?? "";
+  if (aStart !== bStart) return aStart > bStart ? -1 : 1;
+  return 0;
 }
 
 function GoalProgressCard({ progress }: { progress: GoalProgress }) {
@@ -72,7 +94,7 @@ function GoalProgressCard({ progress }: { progress: GoalProgress }) {
           value={
             achieved
               ? achievedWeight != null
-                ? `${achievedDate} に ${achievedWeight.toFixed(1)} kg`
+                ? `${achievedDate} に 達成(${achievedWeight.toFixed(1)} kg)`
                 : "達成!"
               : remaining == null
                 ? "—"

--- a/src/styles.css
+++ b/src/styles.css
@@ -158,6 +158,20 @@ input[type="file"] {
   display: grid;
   gap: 12px;
 }
+.past-goals {
+  border-top: 1px solid var(--divider);
+  padding-top: 12px;
+}
+.past-goals summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+.past-goals summary:hover {
+  color: var(--fg);
+}
 .goal-card {
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
## 概要
- 達成済み目標の「目標まで」表示を「YYYY-MM-DD に 達成(xx.x kg)」に変更しました。
- 最新の目標が一番上に出るよう、目標カードを新しい期間順に並べ替えました。
- 過去の目標は初期状態で閉じたトグル内に表示するようにしました。

## 確認したこと
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build
- git diff --check