### PR TITLE
目標を削除できるようにする

### DIFF
--- a/src/ManageApp.tsx
+++ b/src/ManageApp.tsx
@@ -13,7 +13,7 @@ import {
   saveMeasurements,
   subscribePage,
 } from "./lib/store";
-import { computeGoalProgresses } from "./lib/stats";
+import { computeGoalProgresses, type GoalProgress } from "./lib/stats";
 import { GoalCard } from "./components/GoalCard";
 import { GoalEditor } from "./components/GoalEditor";
 import { LabelEditor } from "./components/LabelEditor";
@@ -72,6 +72,23 @@ export default function ManageApp() {
 
   async function handleGoalSave(goal: Goal) {
     const nextGoals = [...goals, { ...goal, id: createGoalId() }];
+    if (FIREBASE_ENABLED && user && isOwner) {
+      await ensurePageOwner(pageId, user.uid);
+      await saveGoals(pageId, nextGoals);
+    } else {
+      setPage((prev) => ({
+        ...prev,
+        goals: nextGoals,
+        goal: nextGoals[nextGoals.length - 1],
+      }));
+    }
+  }
+
+  async function handleGoalDelete(progress: GoalProgress) {
+    if (!progress.hasGoal) return;
+    const label = `${progress.startDate} 〜 ${progress.endDate} の目標`;
+    if (!window.confirm(`${label} を削除しますか？`)) return;
+    const nextGoals = goals.filter((goal) => !isSameGoal(goal, progress));
     if (FIREBASE_ENABLED && user && isOwner) {
       await ensurePageOwner(pageId, user.uid);
       await saveGoals(pageId, nextGoals);
@@ -161,7 +178,10 @@ export default function ManageApp() {
         </div>
       )}
 
-      <GoalCard progresses={progresses} />
+      <GoalCard
+        progresses={progresses}
+        onDelete={isOwner || !FIREBASE_ENABLED ? handleGoalDelete : undefined}
+      />
 
       <div className="card">
         <h2>体重の推移</h2>
@@ -246,6 +266,15 @@ function isoDate(d: Date): string {
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const da = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${da}`;
+}
+
+function isSameGoal(goal: Goal, progress: GoalProgress): boolean {
+  if (progress.goalId && goal.id === progress.goalId) return true;
+  return (
+    goal.startDate === progress.startDate &&
+    goal.endDate === progress.endDate &&
+    goal.targetKg === progress.targetKg
+  );
 }
 
 function mergeMeasurements(

--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -2,9 +2,10 @@ import type { GoalProgress } from "../lib/stats";
 
 type Props = {
   progresses: GoalProgress[];
+  onDelete?: (progress: GoalProgress) => void;
 };
 
-export function GoalCard({ progresses }: Props) {
+export function GoalCard({ progresses, onDelete }: Props) {
   const visible = progresses
     .filter((progress) => progress.hasGoal)
     .sort(compareNewestFirst);
@@ -23,7 +24,7 @@ export function GoalCard({ progresses }: Props) {
 
   return (
     <div className="goal-cards">
-      <GoalProgressCard progress={latest} />
+      <GoalProgressCard progress={latest} onDelete={onDelete} />
       {past.length > 0 && (
         <details className="past-goals">
           <summary>過去の目標 {past.length}件</summary>
@@ -32,6 +33,7 @@ export function GoalCard({ progresses }: Props) {
               <GoalProgressCard
                 key={progress.goalId ?? `${progress.startDate}-${progress.endDate}`}
                 progress={progress}
+                onDelete={onDelete}
               />
             ))}
           </div>
@@ -51,7 +53,13 @@ function compareNewestFirst(a: GoalProgress, b: GoalProgress): number {
   return 0;
 }
 
-function GoalProgressCard({ progress }: { progress: GoalProgress }) {
+function GoalProgressCard({
+  progress,
+  onDelete,
+}: {
+  progress: GoalProgress;
+  onDelete?: (progress: GoalProgress) => void;
+}) {
   const {
     startDate,
     endDate,
@@ -77,7 +85,18 @@ function GoalProgressCard({ progress }: { progress: GoalProgress }) {
         <h2>
           {startDate} 〜 {endDate} の進捗（目標 -{targetKg} kg）
         </h2>
-        {achieved && <span className="goal-badge">達成</span>}
+        <div className="goal-card-actions">
+          {achieved && <span className="goal-badge">達成</span>}
+          {onDelete && (
+            <button
+              className="ghost danger small"
+              type="button"
+              onClick={() => onDelete(progress)}
+            >
+              削除
+            </button>
+          )}
+        </div>
       </div>
       <div className="goal-grid">
         <Stat label="開始時体重" value={fmtKg(startWeight)} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,6 +77,19 @@ button.ghost:hover {
   background: var(--fg);
   color: var(--bg);
 }
+button.small {
+  font-size: 11px;
+  padding: 4px 10px;
+}
+button.danger {
+  color: var(--danger);
+  border-color: rgba(124, 29, 29, 0.35);
+}
+button.danger:hover {
+  color: var(--bg);
+  background: var(--danger);
+  border-color: var(--danger);
+}
 
 input[type="number"],
 input[type="file"],
@@ -191,6 +204,12 @@ input[type="file"] {
 }
 .goal-card-heading h2 {
   margin-bottom: 0;
+}
+.goal-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
 }
 .goal-badge {
   flex: 0 0 auto;


### PR DESCRIPTION
## 概要
- 管理画面の目標カードに削除ボタンを追加しました。
- 削除前に確認ダイアログを出すようにしました。
- 削除後は `goals` 配列を保存し直し、最後の目標を現在目標として同期します。

## 確認したこと
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build
- git diff --check